### PR TITLE
feat(waf): add AWS WAF integration with managed rules

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -240,11 +240,13 @@ variable "load_balancer" {
     redirect_http_to_https     = optional(bool, true)
     certificate_arn            = optional(string)
     create_acm_certificate     = optional(bool, true)
+    waf_enabled                = optional(bool, false)
   })
   default = {
     enable_deletion_protection = false
     redirect_http_to_https     = true
     create_acm_certificate     = true
+    waf_enabled                = false
   }
 }
 
@@ -329,4 +331,37 @@ variable "ok_actions" {
   description = "The list of actions to execute when this alarm transitions into an OK state from any other state. Each action is specified as an Amazon Resource Name (ARN)."
   type        = list(string)
   default     = []
+}
+
+variable "waf_config" {
+  description = "Configuration for AWS WAF managed rules. Object containing 'aws-managed-rules' map."
+  type        = map(map(list(string)))
+  default = {
+    "aws-managed-rules" = {
+      "AWSManagedRulesAmazonIpReputationList" = []
+      "AWSManagedRulesKnownBadInputsRuleSet"  = []
+      "AWSManagedRulesSQLiRuleSet"            = []
+      "AWSManagedRulesLinuxRuleSet"           = []
+      "AWSManagedRulesUnixRuleSet"            = []
+      "AWSManagedRulesCommonRuleSet" = [
+        "SizeRestrictions_BODY",
+        "GenericRFI_BODY"
+      ]
+    }
+  }
+}
+
+variable "waf_logging_enabled" {
+  description = "Enable WAF logging to CloudWatch."
+  type        = bool
+  default     = false
+}
+
+variable "waf_logging_config" {
+  description = "Configuration for WAF logging (retention, kms_key_id)."
+  type = object({
+    retention_in_days = number
+    kms_key_id        = optional(string)
+  })
+  default = null
 }

--- a/waf.tf
+++ b/waf.tf
@@ -1,0 +1,122 @@
+locals {
+  # Priority map for standard AWS Managed Rules to ensure correct order
+  waf_rule_priorities = {
+    "AWSManagedRulesAmazonIpReputationList" = 10
+    "AWSManagedRulesKnownBadInputsRuleSet"  = 20
+    "AWSManagedRulesSQLiRuleSet"            = 30
+    "AWSManagedRulesLinuxRuleSet"           = 40
+    "AWSManagedRulesUnixRuleSet"            = 50
+    "AWSManagedRulesCommonRuleSet"          = 60
+  }
+
+  waf_rules = [
+    for name, exclusions in var.waf_config["aws-managed-rules"] : {
+      name        = name
+      vendor_name = "AWS"
+      # Use known priority or fallback to alphabetical index offset (100+)
+      priority = lookup(local.waf_rule_priorities, name, 100)
+      version  = null
+      action   = { block = {} }
+      statement = {
+        name        = name
+        vendor_name = "AWS"
+        rule_action_override = {
+          for rule_name in exclusions : rule_name => {
+            action = "count"
+          }
+        }
+      }
+      visibility_config = {
+        cloudwatch_metrics_enabled = true
+        metric_name                = name
+        sampled_requests_enabled   = true
+      }
+    }
+  ]
+}
+
+module "waf" {
+  source  = "cloudposse/waf/aws"
+  version = "~> 1.11.0"
+
+  count = var.load_balancer.waf_enabled ? 1 : 0
+
+  name = "${var.stage_name}-waf"
+
+  scope = "REGIONAL"
+
+  default_action = "allow"
+
+  managed_rule_group_statement_rules = local.waf_rules
+
+  # https://docs.aws.amazon.com/waf/latest/developerguide/logging-cw-logs.html#logging-cw-logs-naming
+  log_destination_configs = var.waf_logging_enabled ? [module.waf_log_group[0].cloudwatch_log_group_arn] : []
+
+  tags = var.tags
+
+  visibility_config = {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.stage_name}-waf-metric"
+    sampled_requests_enabled   = true
+  }
+}
+
+module "waf_log_group" {
+  source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
+  version = "~> 5.0"
+
+  count = var.load_balancer.waf_enabled && var.waf_logging_enabled ? 1 : 0
+
+  name              = "aws-waf-logs-${var.stage_name}-waf"
+  retention_in_days = var.waf_logging_config.retention_in_days
+  kms_key_id        = var.waf_logging_config.kms_key_id
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "waf_log_policy" {
+  count = var.load_balancer.waf_enabled && var.waf_logging_enabled ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    principals {
+      type = "Service"
+      identifiers = [
+        "delivery.logs.amazonaws.com",
+        "wafv2.amazonaws.com"
+      ]
+    }
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = ["${module.waf_log_group[0].cloudwatch_log_group_arn}:*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:${data.aws_partition.current.partition}:logs:${var.region}:${data.aws_caller_identity.current.account_id}:*"]
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "waf" {
+  count = var.load_balancer.waf_enabled && var.waf_logging_enabled ? 1 : 0
+
+  policy_name     = "aws-waf-logs-${var.stage_name}-policy"
+  policy_document = data.aws_iam_policy_document.waf_log_policy[0].json
+}
+
+resource "aws_wafv2_web_acl_association" "this" {
+  for_each = var.load_balancer.waf_enabled ? module.ecs_alb : {}
+
+  resource_arn = each.value.arn
+  web_acl_arn  = module.waf[0].arn
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}

--- a/waf.tf
+++ b/waf.tf
@@ -10,18 +10,18 @@ locals {
   }
 
   waf_rules = [
-    for name, exclusions in var.waf_config["aws-managed-rules"] : {
+    for i, name in sort(keys(var.waf_config["aws-managed-rules"])) : {
       name        = name
       vendor_name = "AWS"
       # Use known priority or fallback to alphabetical index offset (100+)
-      priority = lookup(local.waf_rule_priorities, name, 100)
+      priority = lookup(local.waf_rule_priorities, name, 100 + (i * 10))
       version  = null
       action   = { block = {} }
       statement = {
         name        = name
         vendor_name = "AWS"
         rule_action_override = {
-          for rule_name in exclusions : rule_name => {
+          for rule_name in var.waf_config["aws-managed-rules"][name] : rule_name => {
             action = "count"
           }
         }
@@ -68,8 +68,8 @@ module "waf_log_group" {
   count = var.load_balancer.waf_enabled && var.waf_logging_enabled ? 1 : 0
 
   name              = "aws-waf-logs-${var.stage_name}-waf"
-  retention_in_days = var.waf_logging_config.retention_in_days
-  kms_key_id        = var.waf_logging_config.kms_key_id
+  retention_in_days = try(var.waf_logging_config.retention_in_days, 7)
+  kms_key_id        = try(var.waf_logging_config.kms_key_id, null)
 
   tags = var.tags
 }


### PR DESCRIPTION
Add optional WAF support for ALB with AWS Managed Rules and CloudWatch logging. Features:
- AWS Managed Rules (IP Reputation, SQLi, Bad Inputs, Linux/Unix, Common)
- Configurable rule exclusions/overrides
- CloudWatch logging with IAM policies
- Automatic WAF-ALB association